### PR TITLE
fix: 修复系统代写归因与缩放弹窗遮挡

### DIFF
--- a/android/app/src/main/kotlin/com/storage/redirect/x/ui/component/miuix/ScaleDialog.kt
+++ b/android/app/src/main/kotlin/com/storage/redirect/x/ui/component/miuix/ScaleDialog.kt
@@ -18,8 +18,8 @@ import top.yukonga.miuix.kmp.basic.ButtonDefaults
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.basic.TextButton
 import top.yukonga.miuix.kmp.basic.TextField
-import top.yukonga.miuix.kmp.overlay.OverlayDialog
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
+import top.yukonga.miuix.kmp.window.WindowDialog
 
 @Composable
 fun ScaleDialog(
@@ -28,7 +28,7 @@ fun ScaleDialog(
     volumeState: () -> Float,
     onVolumeChange: (Float) -> Unit,
 ) {
-    OverlayDialog(
+    WindowDialog(
         show = show,
         title = stringResource(R.string.settings_page_scale),
         summary = "80% - 110%",

--- a/srx_core/src/platform/module_paths.rs
+++ b/srx_core/src/platform/module_paths.rs
@@ -2,6 +2,7 @@ pub const MODULE_DIR: &str = "/data/adb/modules/storage.redirect.x";
 pub const CONFIG_DIR: &str = "/data/adb/modules/storage.redirect.x/config";
 // bind mount 到所有进程可访问的位置，系统代写进程降权后仍能读取
 pub const SHARED_CONFIG_DIR: &str = "/dev/srx_config";
-pub const SYSTEM_WRITER_UIDS_FILE: &str =
+pub const SHARED_SYSTEM_WRITER_UIDS_FILE: &str = "/dev/srx_config/system_writer_uids.list";
+pub const MODULE_SYSTEM_WRITER_UIDS_FILE: &str =
     "/data/adb/modules/storage.redirect.x/config/system_writer_uids.list";
 pub const LOG_DIR: &str = "/data/adb/modules/storage.redirect.x/logs";

--- a/srx_core/src/redirect/policy.rs
+++ b/srx_core/src/redirect/policy.rs
@@ -271,25 +271,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn uid_file_candidates_prioritize_shared_mirror() {
-        assert_eq!(
-            SYSTEM_WRITER_UID_FILE_CANDIDATES,
-            [
-                "/dev/srx_config/system_writer_uids.list",
-                "/data/adb/modules/storage.redirect.x/config/system_writer_uids.list",
-            ]
-        );
-    }
-
-    #[test]
-    fn uid_map_line_parses_package_and_uid() {
-        assert_eq!(
-            parse_line("com.tencent.tmgp.sgame:10352\r"),
-            Some(("com.tencent.tmgp.sgame".to_string(), 10352))
-        );
-    }
-
-    #[test]
     fn file_monitor_ui_detects_system_and_oem_file_shells() {
         assert!(is_file_monitor_ui_package("com.android.documentsui"));
         assert!(is_file_monitor_ui_package("com.android.photopicker"));

--- a/srx_core/src/redirect/policy.rs
+++ b/srx_core/src/redirect/policy.rs
@@ -1,5 +1,7 @@
 // 系统代写与共享 UID 策略
-use crate::platform::module_paths::SYSTEM_WRITER_UIDS_FILE;
+use crate::platform::module_paths::{
+    MODULE_SYSTEM_WRITER_UIDS_FILE, SHARED_SYSTEM_WRITER_UIDS_FILE,
+};
 use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -14,6 +16,10 @@ const DOWNLOAD_PROVIDER: &str = "com.android.providers.downloads";
 const DOWNLOAD_PROVIDER_UI: &str = "com.android.providers.downloads.ui";
 const EXTERNAL_STORAGE_PROVIDER: &str = "com.android.externalstorage";
 const MTP_PACKAGE: &str = "com.android.mtp";
+const SYSTEM_WRITER_UID_FILE_CANDIDATES: [&str; 2] = [
+    SHARED_SYSTEM_WRITER_UIDS_FILE,
+    MODULE_SYSTEM_WRITER_UIDS_FILE,
+];
 
 #[derive(Default)]
 struct SharedUidState {
@@ -197,22 +203,27 @@ fn is_shared_uid(uid: i32, packages_by_uid: &HashMap<i32, Vec<String>>) -> bool 
 
 // 基于 mtime 与文件大小
 fn compute_uid_file_fingerprint() -> u64 {
-    let Ok(meta) = std::fs::metadata(SYSTEM_WRITER_UIDS_FILE) else {
-        return 0;
-    };
-    let size = meta.len();
-    let modified = meta
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos() as u64)
-        .unwrap_or(0);
-    size ^ modified
+    for (index, path) in SYSTEM_WRITER_UID_FILE_CANDIDATES.iter().enumerate() {
+        let Ok(meta) = std::fs::metadata(path) else {
+            continue;
+        };
+        let size = meta.len();
+        let modified = meta
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_nanos() as u64)
+            .unwrap_or(0);
+        return size ^ modified ^ ((index as u64 + 1) << 60);
+    }
+    0
 }
 
 fn load_shared_uid_cache(state: &mut SharedUidState, fingerprint: u64) {
-    let file = File::open(SYSTEM_WRITER_UIDS_FILE);
-    let Ok(file) = file else {
+    let file = SYSTEM_WRITER_UID_FILE_CANDIDATES
+        .iter()
+        .find_map(|path| File::open(path).ok());
+    let Some(file) = file else {
         state.uid_by_package.clear();
         state.packages_by_uid.clear();
         state.system_writer_shared_uids.clear();
@@ -258,6 +269,25 @@ fn load_shared_uid_cache(state: &mut SharedUidState, fingerprint: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uid_file_candidates_prioritize_shared_mirror() {
+        assert_eq!(
+            SYSTEM_WRITER_UID_FILE_CANDIDATES,
+            [
+                "/dev/srx_config/system_writer_uids.list",
+                "/data/adb/modules/storage.redirect.x/config/system_writer_uids.list",
+            ]
+        );
+    }
+
+    #[test]
+    fn uid_map_line_parses_package_and_uid() {
+        assert_eq!(
+            parse_line("com.tencent.tmgp.sgame:10352\r"),
+            Some(("com.tencent.tmgp.sgame".to_string(), 10352))
+        );
+    }
 
     #[test]
     fn file_monitor_ui_detects_system_and_oem_file_shells() {


### PR DESCRIPTION
## 问题背景

本 PR 修复两个已在真机上复现的问题：

1. 王者荣耀启用存储重定向后，通过 MediaProvider 代写 `Documents/ringtone` 时，记录中的执行进程显示为 MediaProvider，实际发起方却无法正确归因到王者荣耀，最终可能绕过应用重定向规则并在公共路径创建文件。
2. 主题设置页面点击修改页面缩放、输入数值时，弹出的对话框处于页面级浮层，层级低于根页面的浮动底栏，导致对话框底部内容和操作区域被底栏遮挡。

## 根因

### MediaProvider 系统代写归因

系统代写 UID 映射原本只从模块目录 `/data/adb/modules/storage.redirect.x/config/system_writer_uids.list` 读取。MediaProvider 等被注入进程在降权及挂载命名空间环境中无法稳定访问该路径，因此无法读取 `com.tencent.tmgp.sgame:10352` 等映射。策略层只能看到 MediaProvider 自身，不能还原实际调用应用，应用级重定向规则随之失效。

此外，缓存指纹只跟踪单一路径。当所有进程可访问的共享镜像稍后出现时，缓存也无法根据数据源切换及时重载。

### 页面缩放对话框

缩放数值编辑使用 `OverlayDialog`，它属于当前页面的 overlay 层；应用根部的浮动底栏位于更高层级，因此会覆盖对话框。页面级 overlay 对输入法和系统导航区域的处理也不适合这个需要文本输入的弹窗。

## 修复实现

### MediaProvider 系统代写归因

- 将 UID 映射拆分为两个明确路径：
  - 共享镜像：`/dev/srx_config/system_writer_uids.list`
  - 模块目录回退：`/data/adb/modules/storage.redirect.x/config/system_writer_uids.list`
- 策略层按上述顺序选择首个可访问文件，优先读取对注入进程可见的 `/dev/srx_config`，同时保留模块目录作为兼容回退。
- 文件指纹加入候选来源标识以及文件大小、修改时间。即使两个文件元数据碰巧相同，或共享镜像在进程启动后才出现，缓存也会识别来源切换并重新加载。


修复后，MediaProvider 代写请求可以恢复到王者荣耀 UID，再按 `com.tencent.tmgp.sgame` 的应用策略重定向至应用私有映射目录，不再落入公共 `Documents/ringtone`。

### 页面缩放对话框

- 将 `ScaleDialog` 从页面级 `OverlayDialog` 切换为窗口级 `WindowDialog`。
- 窗口级对话框位于浮动底栏之上，并由窗口层正确处理输入法与导航栏 inset，避免数值输入和底部操作区域被遮挡。

## 影响范围

- 不改变普通应用直接文件访问的重定向逻辑。
- 只调整系统代写 UID 映射文件的读取优先级、回退与缓存失效条件。
- 不改变页面缩放数值范围、状态更新或保存逻辑，只修正弹窗承载层级。

## 验证

### 真机验证

- 设备：duchamp，arm64-v8a，KernelSU `ksud 3.2.5`。
- 编译并刷入 arm64 模块，重启后确认设备中的核心库哈希与本地构建一致。
- 冷启动王者荣耀 `com.tencent.tmgp.sgame`（UID 10352）复测 `Documents/ringtone`：
  - 记录到 118 次 redirect、0 次 allow。
  - 文件写入 `/storage/emulated/0/Android/data/com.tencent.tmgp.sgame/sdcard/Documents/ringtone/...`。
  - 应用私有后端产生 60 个文件；公共路径没有新增文件。
- 安装包含 UI 修复的 debug APK 后，已人工确认页面缩放数值弹窗不再被底栏遮挡。

### 本地检查与构建

- `python -B -m compileall -q scripts`
- `cargo fmt --all --check`
- `cargo clippy --manifest-path srx_core/Cargo.toml --target aarch64-linux-android -- -D warnings`
- `cargo check -p srx_core --target aarch64-linux-android --tests`
- `./gradlew :app:lintDebug`
- `./gradlew :app:testDebugUnitTest`
- `python scripts/build.py build-zygisk --abi arm64-v8a`
- `python scripts/build.py build-apk --abi arm64-v8a`

本地 Maven Central 对 Gradle 的请求返回 403，因此本地 Android 检查临时使用阿里云镜像完成依赖解析；镜像配置已在验证后删除，未包含在提交中。GitHub CI 使用仓库原始配置验证通过。

### GitHub Actions

- 完整 `构建测试` workflow：成功
- run: https://github.com/z1298808165/Storage-redirection-X-Public/actions/runs/29073074190
- 准备构建元信息：成功
- Clippy、Android Lint、arm64 模块与 APK 构建、产物校验：成功
- Android 13 / 14 / 15 / 16 模拟器端到端测试：全部成功


