### PR TITLE
fix: 修复允许路径媒体读取与监视路径误报

### DIFF
--- a/srx_core/src/hook/fuse_fixer/install.rs
+++ b/srx_core/src/hook/fuse_fixer/install.rs
@@ -393,7 +393,9 @@ fn should_allow_srx_fuse_access(bytes: &[u8], uid: u32) -> bool {
     let Ok(path) = std::str::from_utf8(bytes) else {
         return false;
     };
-    media_fuse::should_allow_private_owner_sqlite_access(path, uid as i32)
+    let caller_uid = uid as i32;
+    media_fuse::should_allow_configured_real_path_access(path, caller_uid)
+        || media_fuse::should_allow_private_owner_sqlite_access(path, caller_uid)
 }
 
 fn should_force_userspace(bytes: &[u8]) -> bool {

--- a/srx_core/src/hook/media_fuse.rs
+++ b/srx_core/src/hook/media_fuse.rs
@@ -31,6 +31,76 @@ pub fn should_allow_private_owner_sqlite_access(path: &str, caller_uid: i32) -> 
     should_allow_private_owner_sqlite_access_for_caller(path, caller_uid, &caller_package)
 }
 
+pub fn should_allow_configured_real_path_access(path: &str, caller_uid: i32) -> bool {
+    if caller_uid < ANDROID_APP_UID_START {
+        return false;
+    }
+
+    let user_id = platform::user_id_from_uid(caller_uid);
+    let normalized_path = normalize_fuse_storage_path(path, user_id);
+    if normalized_path.is_empty()
+        || paths::has_unsafe_segments(&normalized_path)
+        || paths::extract_user_id_from_storage_path(&normalized_path) != user_id
+    {
+        return false;
+    }
+
+    let mut packages = policy::get_packages_for_uid(caller_uid);
+    if packages.is_empty() {
+        policy::refresh_shared_uid_cache();
+        packages = policy::get_packages_for_uid(caller_uid);
+    }
+    packages.sort();
+    packages.dedup();
+
+    let config = SettingsHub::instance();
+    for package in packages {
+        if package.is_empty()
+            || policy::is_media_intermediate_package(&package)
+            || policy::is_system_writer_package(&package)
+        {
+            continue;
+        }
+
+        let excluded_paths = config.get_excluded_real_paths(&package, caller_uid);
+        if excluded_paths
+            .iter()
+            .any(|rule| paths::matches(rule, &normalized_path, true))
+        {
+            continue;
+        }
+
+        let allowed_paths = config.get_allowed_real_paths(&package, caller_uid);
+        if !allowed_paths
+            .iter()
+            .any(|rule| paths::matches(rule, &normalized_path, true))
+        {
+            continue;
+        }
+
+        return true;
+    }
+
+    false
+}
+
+fn normalize_fuse_storage_path(path: &str, user_id: i32) -> String {
+    if path.is_empty() || user_id < 0 {
+        return String::new();
+    }
+
+    let normalized = paths::normalize(path);
+    if paths::extract_user_id_from_storage_path(&normalized) >= 0 {
+        return normalized;
+    }
+
+    let relative = normalized.trim_start_matches('/');
+    if relative.is_empty() {
+        return String::new();
+    }
+    paths::normalize(&format!("/storage/emulated/{}/{}", user_id, relative))
+}
+
 pub fn should_allow_private_owner_sqlite_access_for_caller(
     path: &str,
     caller_uid: i32,

--- a/srx_core/src/hook/ops/mutation.rs
+++ b/srx_core/src/hook/ops/mutation.rs
@@ -8,6 +8,7 @@ use super::super::util::c_str_to_string;
 use crate::platform::paths;
 use crate::redirect::{policy, process_redirect_path, record_redirect_hit};
 use libc::{AT_FDCWD, c_char, c_int, c_void, mode_t, off_t, timespec};
+use std::borrow::Cow;
 use std::ffi::CString;
 
 pub unsafe extern "C" fn hooked_mkdir(pathname: *const c_char, mode: mode_t) -> c_int {
@@ -191,10 +192,12 @@ where
     let redirect_result = process_redirect_path(hub, &path_text);
     diagnostic::log_diag_redirect_decision(hub, op_name, &path_text, &redirect_result);
 
+    let mut final_path: Cow<'_, str> = Cow::Borrowed(path_text.as_str());
     let result = if redirect_result.is_redirect() {
         record_redirect_hit(hub, op_name, &path_text, &redirect_result.new_path);
         runtime::ensure_redirect_parent_dirs(&redirect_result.new_path, mode);
-        if let Ok(c_path) = CString::new(redirect_result.new_path) {
+        if let Ok(c_path) = CString::new(redirect_result.new_path.as_str()) {
+            final_path = Cow::Owned(redirect_result.new_path);
             call_original(c_path.as_ptr())
         } else {
             call_original(pathname)
@@ -207,7 +210,7 @@ where
     } else {
         0
     };
-    monitor::record_mkdir_result(hub, op_name, &path_text, result, error_no);
+    monitor::record_mkdir_result(hub, op_name, final_path.as_ref(), result, error_no);
     result
 }
 
@@ -837,10 +840,12 @@ where
     let redirect_result = process_redirect_path(hub, &path_text);
     diagnostic::log_diag_redirect_decision(hub, op_name, &path_text, &redirect_result);
 
+    let mut final_path: Cow<'_, str> = Cow::Borrowed(path_text.as_str());
     let result = if redirect_result.is_redirect() {
         record_redirect_hit(hub, op_name, &path_text, &redirect_result.new_path);
         runtime::ensure_redirect_parent_dirs(&redirect_result.new_path, mode);
-        if let Ok(c_path) = CString::new(redirect_result.new_path) {
+        if let Ok(c_path) = CString::new(redirect_result.new_path.as_str()) {
+            final_path = Cow::Owned(redirect_result.new_path);
             call_original(c_path.as_ptr())
         } else {
             call_original(pathname)
@@ -853,6 +858,6 @@ where
     } else {
         0
     };
-    monitor::record_mkdir_result(hub, op_name, &path_text, result, error_no);
+    monitor::record_mkdir_result(hub, op_name, final_path.as_ref(), result, error_no);
     result
 }


### PR DESCRIPTION
## 问题背景

本 PR 修复两个已在用户设备上复现、且都涉及 MediaProvider/FUSE 路径处理的问题：

1. 应用已在 `allowed_real_paths` 中允许 `DCIM`、`Documents`、`Download`、`Movies`、`Music`、`Pictures` 等真实路径，但通过系统文件选择器或 MediaProvider 读取图片后仍可能无法发送。文件在界面中可选择，实际读取阶段却被 FUSE 路径校验拒绝。
2. 王者荣耀 `com.tencent.tmgp.sgame` 的文件已经成功隔离到应用私有重定向目录，但文件监视仍显示原公共路径创建成功，使监视结果与真实落盘位置不一致。

## 根因

### 允许路径的媒体读取失败

应用进程自身的挂载命名空间已经按配置恢复了允许路径，说明配置读取和 mount 处理正常。但文件经 SAF/MediaProvider 打开时，还会经过 MediaProvider FUSE 的 `is_app_accessible_path` 判断。

原有 FUSE 兼容逻辑只为 `Android/media` 下特定私有 SQLite 文件及 sidecar 增加访问例外，没有将普通应用配置中的 `allowed_real_paths` 纳入判断。因此，同一文件在应用挂载命名空间中可见，却可能在 MediaProvider FUSE 读取阶段被拒绝。

### 文件监视显示原路径成功

`mkdir`、`mkdirat`、`mknod`、`mknodat` 在执行重定向后，实际传给 libc 的是私有最终路径，但监视层仍固定记录请求时的原路径，并沿用最终操作的成功返回值。

这会产生“公共原路径创建成功”的误导记录，同时因为记录路径不是 `Android/data` 私有路径，也绕过了监视模块已有的私有沙箱过滤。

## 修复实现

### FUSE 允许路径判断

- 新增配置允许路径的 FUSE 访问判断，将 FUSE 相对路径和别名规范化到 `/storage/emulated/<user>/...`。
- 校验调用 UID 与路径所属 Android 用户一致，拒绝不安全路径段和跨用户路径。
- 按调用 UID 解析实际应用包名，并过滤 MediaProvider、系统代写方等中间进程包名。
- 保持排除规则优先级：路径命中 `allowed_real_paths` 排除项时不会放行。
- 使用现有路径匹配语义判断普通允许规则，支持仓库已有的通配符行为。
- 在 FuseFixer 的访问判断中同时保留原有私有 SQLite 例外，不改变原兼容逻辑。

### 监视路径修正

- `mkdir` / `mkdirat` / `mknod` / `mknodat` 完成重定向后，将实际执行路径传给监视层。
- 默认隔离到 `Android/data/<package>/sdcard/...` 的创建操作会继续使用现有私有沙箱过滤，不再显示为公共路径创建成功。
- 若显式映射到其他公共路径，监视记录会显示真实最终路径。
- 路径转换失败并回退原调用时，仍记录原调用路径，确保记录与实际执行保持一致。

## 影响范围与兼容性

- 不修改配置格式、配置项或管理应用交互，不需要用户迁移配置。
- 只对调用应用明确配置为允许、且未命中排除规则的同用户路径增加 FUSE 放行。
- 不放行 MediaProvider、系统代写方等中间进程自身的应用规则，也不允许跨 Android 用户访问。
- 不改变文件重定向结果，只修正目录/节点创建操作的监视路径与私有路径过滤行为。
- 原有 `Android/media` 私有 SQLite 兼容逻辑保持不变。

## Commit

- `4cd7e36 fix: 放行配置允许路径的媒体读取`
- `fd92bdc fix: 修正重定向创建操作的监视路径`

两个提交分别对应访问修复和监视记录修复，职责独立。

## 验证

### 用户真机复测

用户 `0GqstmoB` 使用 ARM64 测试模块复测通过：

- 在应用允许路径中添加图片所在目录后，图片可以正常发送。
- 王者荣耀文件继续正确落入应用私有重定向目录。
- 文件监视不再将私有目录中的成功创建误报为原公共路径创建成功。

### 本地检查与构建

- `python -B -m compileall -q scripts`
- `cargo fmt --all --check`
- `cargo clippy --manifest-path srx_core/Cargo.toml --target aarch64-linux-android -- -D warnings`
- `./android/gradlew -p ./android :app:lintDebug`
- `python scripts/build.py build-zygisk --abi arm64-v8a --ndk <NDK 29 path> -v`
- ARM64 模块 ZIP 完整性检查通过。
- 差异中没有新增 Rust 内联测试、临时文件或调试输出。

### GitHub Actions

完整 `构建测试` workflow 已在最终提交 `fd92bdc19240ab03260232fa2ad243114b0970c5` 上通过：

- Run: https://github.com/z1298808165/Storage-redirection-X-Public/actions/runs/29182991862
- Clippy：通过
- Android Lint：通过
- Zygisk 模块与 APK 构建、产物校验：通过
- Android 13 / 14 / 15 / 16 模拟器端到端测试：全部通过

## 关联与风险

- 暂无关联 Issue。
- 潜在风险主要集中在 MediaProvider FUSE 热路径的调用方识别；实现通过 UID、Android 用户、包名类型、排除规则和显式允许规则多层约束限制放行范围。
- 文件监视变化属于准确性修复：默认重定向到私有沙箱的创建操作将不再作为公共存储事件展示。