### PR TITLE
fix: 防止系统代写调用方跨应用误归因

### DIFF
--- a/srx_core/src/redirect/writer.rs
+++ b/srx_core/src/redirect/writer.rs
@@ -205,6 +205,10 @@ pub fn maybe_override_system_writer_caller_by_path(
     }
 
     let inferred_uid = policy::get_uid_for_package(&inferred);
+    if !effective_caller_package.is_empty() && inferred_uid != *effective_caller_uid {
+        return;
+    }
+
     if inferred_uid >= ANDROID_APP_UID_START {
         *effective_caller_uid = inferred_uid;
     }


### PR DESCRIPTION
## 问题背景

系统组件代写公共存储文件时，重定向引擎会结合调用方身份和目标路径判断应使用哪个应用的配置。

当调用方身份已经明确、但该应用未启用重定向时，如果目标路径恰好命中另一已启用应用的路径映射，原逻辑仍可能用路径推断结果覆盖已知调用方。若两者属于不同 UID，后续会错误应用另一应用的重定向配置，造成跨应用误归因和非预期的文件重定向。

## 根因

`maybe_override_system_writer_caller_by_path` 只在已知调用方已启用重定向时提前返回。对于已知但未启用重定向的调用方，它仍会在当前 Android 用户的全部已启用应用配置中按路径查找匹配项，并直接将有效包名和 UID 替换为推断结果。

路径匹配可以辅助恢复未知调用方，或在 shared UID 内识别具体包名，但不能作为跨 UID 覆盖已知身份的依据。原实现缺少这一身份边界校验。

## 修复实现

- 路径推断得到候选应用后，先解析候选应用 UID。
- 当原调用方包名已知时，仅允许候选应用 UID 与原调用方 UID 相同的覆盖。
- 若候选应用属于不同 UID，或候选 UID 无法解析，则保留原调用方身份并跳过路径覆盖。
- 保留调用方未知时的路径归属恢复能力。
- 保留 shared UID 场景下按路径在同一 UID 内消歧具体包名的能力。

## 修复效果

已知调用方不会再因为目标路径命中其他应用的配置而被跨 UID 替换，系统代写请求将继续按真实调用方的启用状态处理。路径推断仍可用于身份未知及 shared UID 场景，不影响现有兼容逻辑。

## 影响范围与兼容性

- 不修改配置格式、配置项或管理应用交互，无需迁移配置。
- 不改变已启用调用方优先使用自身配置的现有行为。
- 不改变未知调用方的路径推断行为。
- 同 UID 多包场景仍可按路径完成包名消歧。
- 行为收紧仅针对“调用方身份已知，但路径推断候选属于其他 UID”的情况。

## Commit

- `274457b fix: 防止系统代写调用方跨应用误归因`

本 PR 仅包含一个单一职责修复提交。

## 验证

### 本地检查与构建

- `cargo fmt --all --check`
- `cargo clippy --manifest-path srx_core/Cargo.toml --target aarch64-linux-android -- -D warnings`
- `./android/gradlew :app:lintDebug`
- `python scripts/build.py build-zygisk --abi arm64-v8a`
- `python scripts/build.py build-apk --abi arm64-v8a`
- ARM64 Zygisk 模块与 release APK 构建成功。
- 差异中没有新增 Rust 内联测试、临时文件或无关改动。

### GitHub Actions

完整 `构建测试` workflow 已在最终提交 `274457b460c5da29f6cc0d96a8394002ed5dc42d` 上通过：

- Run: https://github.com/z1298808165/Storage-redirection-X-Public/actions/runs/29189628854
- Clippy：通过
- Android Lint：通过
- Zygisk 模块与 APK 构建、产物校验：通过
- Android 13 / 14 / 15 / 16 模拟器端到端测试：全部通过
- 自动正式发布：按预期跳过

## 关联与风险

- 暂无关联 Issue。
- 潜在风险集中在系统代写调用方的路径归属推断。修复仅增加已知身份的同 UID 限制，不改变未知身份恢复和 shared UID 消歧，因此影响范围较小。


